### PR TITLE
chore(hooks): add pre-commit hook for fast local checks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# pre-commit — fast local checks before a commit is created.
+#
+# Enable once per clone:
+#   git config core.hooksPath .githooks
+#
+# Bypass once (emergencies only):
+#   git commit --no-verify
+#
+# Checks (all fast — should stay well under 1s):
+#   1. Plugin manifest JSON files parse as valid JSON.
+#   2. Skills review (same script as pre-push, but without --strict so
+#      warnings don't block local iteration; pre-push and CI still gate them).
+#   3. No leftover merge conflict markers in staged content.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT="${SKILLS_REVIEW_SCRIPT:-${REPO_ROOT}/scripts/review-skills.py}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "pre-commit: python3 not on PATH — skipping checks." >&2
+    exit 0
+fi
+
+# 1. Validate plugin manifests parse as JSON. Mirrors CI workflow.
+#    All manifests checked in one python invocation to keep the hook snappy.
+manifests=()
+while IFS= read -r -d '' manifest; do
+    manifests+=("$manifest")
+done < <(find "$REPO_ROOT" -path "*/.claude-plugin/*.json" -not -path "*/.git/*" -print0)
+
+if (( ${#manifests[@]} > 0 )); then
+    if ! python3 - "${manifests[@]}" <<'PY'
+import json, sys
+bad = []
+for path in sys.argv[1:]:
+    try:
+        with open(path) as f:
+            json.load(f)
+    except Exception as e:
+        bad.append(f"{path}: {e}")
+if bad:
+    for line in bad:
+        print(f"pre-commit: invalid JSON in {line}", file=sys.stderr)
+    sys.exit(1)
+PY
+    then
+        exit 1
+    fi
+fi
+
+# 2. Skills review. No --strict here: warnings shouldn't block a WIP commit.
+#    pre-push runs with the same defaults; CI is the strict gate.
+if [[ -f "$SCRIPT" ]]; then
+    if ! python3 "$SCRIPT" "$REPO_ROOT" --quiet; then
+        cat >&2 <<'EOF'
+
+pre-commit: skills review failed.
+  - fix the errors above, or
+  - bypass once with  git commit --no-verify  (use sparingly).
+
+EOF
+        exit 1
+    fi
+fi
+
+# 3. Merge conflict markers in staged content.
+if git diff --cached --check >/dev/null 2>&1; then
+    :
+else
+    # --check also flags whitespace errors; re-grep for conflict markers
+    # specifically so we only fail on real conflicts.
+    if git diff --cached -U0 | grep -E '^\+(<{7}|={7}|>{7})( |$)' >/dev/null; then
+        echo "pre-commit: merge conflict markers in staged changes." >&2
+        exit 1
+    fi
+fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -13,7 +13,9 @@ echo "Setting up rudder-agent-skills development environment..."
 
 # Enable git hooks
 git config core.hooksPath .githooks
-echo "✓ Git hooks enabled (.githooks/pre-push will run before each push)"
+echo "✓ Git hooks enabled:"
+echo "    .githooks/pre-commit  — JSON manifest + skills review + conflict markers"
+echo "    .githooks/pre-push    — strict skills review (matches CI)"
 
 # Verify Python is available for the linter
 if command -v python3 >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Adds `.githooks/pre-commit` running three fast checks (~350ms total): JSON manifest validity, skills review (non-strict), and merge-conflict-marker detection in staged content.
- `pre-push` remains the strict gate (matches CI); `pre-commit` is the fast feedback loop so contributors don't discover failures only at push time.
- Updates `scripts/setup.sh` so newly cloned contributors see both hooks listed on first run.

## Why
Previously the only hook was `pre-push`, which mirrored CI but only ran at push time. Issues like an invalid `.claude-plugin/*.json` or an unresolved conflict marker could ride along in a commit and only surface later. A scoped `pre-commit` catches them in <0.5s without duplicating CI's strict run.

Design notes:
- Linter runs full-repo (not staged-only) because it's already ~170ms; scoping would add complexity for no real speedup.
- Local hook is intentionally **non-strict** (warnings don't block) so WIP commits aren't blocked on style. `pre-push` and CI keep `--strict`.
- All JSON manifests validated in a single `python3` invocation to avoid process-spawn overhead.
- Hooks remain dependency-free native scripts under `.githooks/` + `core.hooksPath` — no `pre-commit`-framework or `lefthook` dependency.

## Test plan
- [ ] `./scripts/setup.sh` on a fresh clone wires `core.hooksPath` and prints both hooks
- [ ] `.githooks/pre-commit` exits 0 on the current tree (~350ms)
- [ ] Breaking a `.claude-plugin/*.json` file causes pre-commit to fail with a clear error
- [ ] Staging a file containing `<<<<<<<` / `=======` / `>>>>>>>` markers causes pre-commit to fail
- [ ] Introducing a skill-review error (e.g. removing a `name:` from a SKILL.md) causes pre-commit to fail
- [ ] `git commit --no-verify` still bypasses the hook (emergency escape hatch)
- [ ] CI workflow `.github/workflows/validate.yml` continues to pass unchanged