### PR TITLE
chore(release): v0.0.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Skills for working with RudderStack via CLI, MCP server, and Terraform.",
-    "version": "1.0.0"
+    "version": "0.0.1"
   },
   "plugins": [
     {
       "name": "rudder-core",
       "source": "./plugins/rudder-core",
       "description": "Cross-tool RudderStack domain knowledge: data catalog, tracking plans, data graphs, instrumentation planning and debugging.",
-      "version": "1.0.0",
+      "version": "0.0.1",
       "author": {
         "name": "RudderStack"
       },
@@ -28,7 +28,7 @@
       "name": "rudder-cli",
       "source": "./plugins/rudder-cli",
       "description": "Workflows for driving the rudder-cli and rudder-typer CLIs: validate, dry-run, apply, import, transformations.",
-      "version": "1.0.0",
+      "version": "0.0.1",
       "author": {
         "name": "RudderStack"
       },
@@ -43,7 +43,7 @@
       "name": "rudder-mcp",
       "source": "./plugins/rudder-mcp",
       "description": "Workflows for RudderStack's MCP server at mcp.rudderstack.com: connect AI/LLM agents to a RudderStack workspace and drive it via MCP tool calls.",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "author": {
         "name": "RudderStack"
       },
@@ -58,7 +58,7 @@
       "name": "rudder-terraform",
       "source": "./plugins/rudder-terraform",
       "description": "Workflows for managing RudderStack with the Terraform provider: provider setup, resource/data-source usage, and plan/apply cycles.",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "author": {
         "name": "RudderStack"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,40 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- `rudder-environment-check` skill (rudder-core): Central diagnostic for all tool prerequisites
-- `rudder-cli-setup` skill (rudder-cli): Installation and authentication guide for rudder-cli
-- `rudder-terraform-setup` skill (rudder-terraform): Terraform and provider setup guide
-- `rudder-mcp-setup` skill (rudder-mcp): MCP server connection configuration
-- Vercel Skills CLI compatibility - skills can now be installed via `npx skills add rudderlabs/rudder-agent-skills` for 40+ coding agents
-- Updated installation documentation with Skills CLI instructions (pre-release and post-release)
-- Credential Security sections to skills handling authentication tokens
-- Handling External Content sections to skills processing API responses
-- `allowed-tools` declarations in skill frontmatter for shell command skills
+## [0.0.1] - 2026-05-28
 
-### Changed
-- Updated all skill descriptions with capability statements before "Use when" clauses
-- Replaced curl|bash installation pattern with GitHub Action reference in CI examples
-
-### Fixed
-- E009: Removed pipe-to-shell pattern in rudder-typer-workflow CI example
-- W004: Added Credential Security sections to rudder-cli-workflow, rudder-transformations, rudder-instrumentation-planning
-- W005: Added Handling External Content sections to rudder-cli-workflow, rudder-import-and-evolve, rudder-transformations, rudder-instrumentation-debugging
-- W006: Added allowed-tools declarations to all skills with shell commands
-- W009: Added capability statements to all skill descriptions
-- W012: Added this CHANGELOG.md file
-
-## [0.1.0] - 2025-04-21
+Initial public release of the `rudder-agent-skills` Claude Code plugin marketplace.
 
 ### Added
-- Initial release of rudder-cli-skills marketplace
-- rudder-cli plugin with skills:
-  - rudder-cli-workflow: Validate, dry-run, and apply workflow
-  - rudder-import-and-evolve: Import and safe evolution patterns
-  - rudder-transformations: Transformation and library management
-  - rudder-typer-workflow: Type-safe SDK generation
-- rudder-core plugin with skills:
-  - rudder-data-catalog: Events, properties, categories, custom types
-  - rudder-instrumentation-debugging: Validation error diagnosis
-  - rudder-instrumentation-planning: Event taxonomy design
-  - rudder-tracking-plans: Tracking plan assembly
+
+#### Plugins
+
+- **`rudder-core`** — cross-tool RudderStack domain knowledge
+  - `rudder-data-catalog` — events, properties, categories, custom types
+  - `rudder-tracking-plans` — tracking plan assembly with nested properties
+  - `rudder-data-graphs` — entity / event / relationship modeling for Audiences
+  - `rudder-instrumentation-planning` — event taxonomy design
+  - `rudder-instrumentation-debugging` — validation error diagnosis
+  - `rudder-design-first-instrumentation` — taxonomy-first instrumentation workflow
+  - `rudder-code-first-instrumentation` — code-first instrumentation workflow
+  - `rudder-environment-check` — diagnostic for all tool prerequisites
+- **`rudder-cli`** — workflows for the `rudder-cli` and `rudder-typer` CLIs
+  - `rudder-cli-setup` — installation and authentication
+  - `rudder-cli-workflow` — validate → dry-run → apply iteration loop
+  - `rudder-import-and-evolve` — import existing resources, safe evolution patterns
+  - `rudder-typer-workflow` — type-safe SDK generation (Swift, Kotlin)
+  - `rudder-transformations` — transformation and library authoring
+- **`rudder-mcp`** — workflows for RudderStack's hosted MCP server at `mcp.rudderstack.com`
+  - `rudder-mcp-setup` — Claude Code connection walkthrough (OAuth)
+  - `rudder-mcp-workflow` — AI-agent usage patterns aligned with the official catalog
+- **`rudder-terraform`** — workflows for the RudderStack Terraform provider
+  - `rudder-terraform-setup` — provider installation and configuration
+  - `rudder-terraform-workflow` — resource and data-source usage patterns
+
+#### Installation paths
+
+- Vercel Skills CLI: `npx skills add rudderlabs/rudder-agent-skills` (works with 40+ coding agents)
+- Claude Code plugin system: `/plugin marketplace add rudderlabs/rudder-agent-skills`
+- Manual symlink / submodule / copy paths documented in `docs/installation.md`
+
+#### Repo tooling
+
+- `scripts/review-skills.py` — self-contained linter covering frontmatter discipline, description quality, progressive disclosure, and security hygiene
+- `.githooks/pre-commit` (fast local checks) and `.githooks/pre-push` (strict gate matching CI)
+- GitHub Actions workflow runs the linter, JSON manifest validation, and `claude plugin validate .` on every PR
+- `step-security/harden-runner` with egress auditing on the validate workflow; all action references SHA-pinned
+
+#### Governance and docs
+
+- `README.md`, `CONTRIBUTING.md`, `docs/installation.md`
+- `.github/pull_request_template.md` and `.github/ISSUE_TEMPLATE/{bug,skill-proposal,config}` for external contributors
+- MIT License

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ claude plugin install rudder-core@rudder-agent-skills
 claude plugin install rudder-cli@rudder-agent-skills
 ```
 
-Pin to a release by appending `@v1.0.0` to the marketplace slug. Update later with `/plugin marketplace update rudder-agent-skills`.
+Pin to a release by appending `@v0.0.1` to the marketplace slug. Update later with `/plugin marketplace update rudder-agent-skills`.
 
 ## Available skills
 


### PR DESCRIPTION
## Summary

First public release of rudder-agent-skills. Mechanical version bump
on top of the consolidation that already landed — no skill content
changes here.

---

## Plugin(s) affected

- [ ] rudder-core
- [ ] rudder-cli
- [ ] rudder-mcp
- [ ] rudder-terraform
- [x] Repo-wide (version + CHANGELOG + README pin example)

---

## Changes

- `.claude-plugin/marketplace.json`
  - `metadata.version`: `1.0.0` → `0.0.1`
  - `rudder-core.version`: `1.0.0` → `0.0.1`
  - `rudder-cli.version`: `1.0.0` → `0.0.1`
  - `rudder-mcp.version`: `0.1.0` → `0.0.1`
  - `rudder-terraform.version`: `0.1.0` → `0.0.1`
- `CHANGELOG.md`: promote `[Unreleased]` → `[0.0.1] - 2026-MM-DD`; add a fresh `[Unreleased]` shell above it
- `README.md` line 84: pin-to-release example `@v1.0.0` → `@v0.0.1`

Plugin-level `plugin.json` files don't carry a `version` field —
per `CONTRIBUTING.md:122`, plugin versions live only in
`marketplace.json`. Nothing to bump there.

---


## Skill testing

No skill behavior changes — version metadata only.

- **Linter:** `python3 scripts/review-skills.py . --strict` → 17 skills, 0 errors, 0 warnings
- **JSON syntax:** `python3 -c "import json; json.load(open('.claude-plugin/marketplace.json'))"` → no errors

---

## Risk / Impact

**Low.** Metadata-only change. The pin example update in the README
is the only contributor-visible change.

---

## After merge

```bash
git checkout main && git pull --ff-only origin main
git tag -a v0.0.1 -m "v0.0.1 — initial public release"
git push origin v0.0.1