### PR TITLE
docs: harden data-graph and cli-workflow skills (root field, apply source-of-truth, join-key verification)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Skills for working with RudderStack via CLI, MCP server, and Terraform.",
-    "version": "0.0.1"
+    "version": "0.0.2"
   },
   "plugins": [
     {
       "name": "rudder-core",
       "source": "./plugins/rudder-core",
       "description": "Cross-tool RudderStack domain knowledge: data catalog, tracking plans, data graphs, instrumentation planning and debugging.",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "author": {
         "name": "RudderStack"
       },
@@ -28,7 +28,7 @@
       "name": "rudder-cli",
       "source": "./plugins/rudder-cli",
       "description": "Workflows for driving the rudder-cli and rudder-typer CLIs: validate, dry-run, apply, import, transformations.",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "author": {
         "name": "RudderStack"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.2] - 2026-05-28
+
+### Changed
+
+- **`rudder-core` / `rudder-data-graphs`** — documented the entity `root`
+  flag (optional, entity-only, multiple roots valid, count not enforced),
+  the relationship sidedness rule (declare once, never the inverse), and a
+  warehouse-agnostic join-key verification step (Snowflake / BigQuery /
+  Postgres / Redshift / Databricks) with a no-access fallback. Added SCD2
+  surrogate-key and ingestion-timestamp modeling edge cases, a date-dimension
+  anti-pattern, per-type `display_name` uniqueness, and a symmetric-name
+  collision fix in the YAML template.
+- **`rudder-cli` / `rudder-cli-workflow`** — documented `--confirm=false`
+  for non-interactive apply (default `--confirm=true` silently no-ops in
+  non-TTY contexts), the full-source-of-truth deletion semantics of `apply`,
+  and `-c <config>` selection for multi-environment workspaces. Fixed the
+  misleading "unexpected deletion" troubleshooting row.
+
 ## [0.0.1] - 2026-05-28
 
 Initial public release of the `rudder-agent-skills` Claude Code plugin marketplace.

--- a/plugins/rudder-cli/skills/rudder-cli-workflow/SKILL.md
+++ b/plugins/rudder-cli/skills/rudder-cli-workflow/SKILL.md
@@ -102,9 +102,12 @@ digraph workflow {
 | `rudder-cli validate -l ./` | Check YAML syntax and semantic rules | After any edit |
 | `rudder-cli apply --dry-run -l ./` | Preview changes without applying | After validation passes |
 | `rudder-cli apply -l ./` | Apply changes to workspace | After dry-run review |
+| `rudder-cli apply --confirm=false -l ./` | Apply without the interactive prompt | CI, piped output, agent contexts |
 | `rudder-cli plan -l ./` | Show detailed execution plan | Alternative to dry-run |
 
 **Note:** `-l ./` specifies the project location (current directory).
+
+**`-c <path>` selects the config (workspace + token).** Pass it explicitly if you maintain per-environment configs (e.g. `~/.rudder/dev.config.json`, `~/.rudder/prod.config.json`); without it, rudder-cli uses the default config that `rudder-cli auth login` last wrote. Verify the target with `rudder-cli workspace info -c <path>` before `apply`.
 
 ## Step 1: Validate
 
@@ -150,10 +153,12 @@ Found N error(s), M warning(s)
 rudder-cli apply --dry-run -l ./
 ```
 
+> **`apply` makes the workspace match your project exactly.** Every remote resource absent from your local YAML — **of any kind** — is deleted, listed under `Removed resources:`. There is no flag to scope apply to a subset (`apply` accepts only `--location`, `--dry-run`, `--confirm`). On a **new** project pointing at an **existing** workspace, expect a large deletion set on the first dry-run; confirm those deletions are acceptable before applying. Treat the project directory as the single source of truth for the whole workspace.
+
 **Output shows:**
 - `New resources:` - Resources that will be created
 - `Updated resources:` - Resources that will be modified (shows diff)
-- `Deleted resources:` - Resources that will be removed
+- `Removed resources:` - Resources in the workspace but not in your project — these will be **deleted**
 
 ### Reading Dry Run Output
 
@@ -182,6 +187,12 @@ rudder-cli apply -l ./
 Only run after:
 1. `validate` passes
 2. `--dry-run` shows expected changes
+
+**Non-interactive runs:** the default `--confirm=true` opens an interactive confirmation prompt. In a non-interactive context (piped output, CI, agent), that prompt **auto-declines and nothing is applied — silently, no error**. Pass `--confirm=false` to apply without prompting:
+
+```bash
+rudder-cli apply --confirm=false -l ./
+```
 
 ## Workflow Examples
 
@@ -277,5 +288,6 @@ done
 | "workspace info" shows wrong workspace | Authenticated to wrong workspace | Run `rudder-cli auth login` with correct token |
 | "Project configuration is valid" but dry-run shows nothing | No changes detected | Verify files are in correct location |
 | Validation passes but dry-run fails | API/auth issue | Run `rudder-cli workspace info` to verify auth |
-| Unexpected resource deletion | State mismatch | Check metadata.import section |
+| `apply` exits without applying, no error | Default `--confirm=true` auto-declined in a non-TTY (piped/CI/agent) context | Re-run with `--confirm=false` |
+| `Removed resources:` lists resources you didn't expect | `apply` is full source of truth — anything in the workspace but not in your project is deleted | Add those resources to your project (e.g. via `rudder-cli import`), or confirm the deletions are intended |
 | Changes not appearing | Wrong project path | Verify `-l ./` points to right directory |

--- a/plugins/rudder-core/skills/rudder-data-graphs/SKILL.md
+++ b/plugins/rudder-core/skills/rudder-data-graphs/SKILL.md
@@ -115,7 +115,7 @@ Every shortlisted source becomes one of:
 | Snowflake | `SELECT TABLE_NAME, COLUMN_NAME FROM <DB>.INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '<schema>' AND TABLE_NAME IN (...)` |
 | BigQuery | `SELECT table_name, column_name FROM <project>.<dataset>.INFORMATION_SCHEMA.COLUMNS WHERE table_name IN (...)` |
 | Postgres / Redshift | `SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = '<schema>' AND table_name IN (...)` |
-| Databricks | `SELECT table_name, column_name FROM system.information_schema.columns WHERE table_name IN (...)`, or `DESCRIBE TABLE <catalog>.<schema>.<table>` |
+| Databricks | `SELECT table_name, column_name FROM system.information_schema.columns WHERE table_catalog = '<catalog>' AND table_schema = '<schema>' AND table_name IN (...)`, or `DESCRIBE TABLE <catalog>.<schema>.<table>` |
 
 If you have no warehouse access, fall back to the rule in **Validation & handoff**: flag every inferred join key and require confirmation before `apply`.
 

--- a/plugins/rudder-core/skills/rudder-data-graphs/SKILL.md
+++ b/plugins/rudder-core/skills/rudder-data-graphs/SKILL.md
@@ -84,8 +84,9 @@ Every shortlisted source becomes one of:
 
 - **Composite primary key** — do not casually pick one component and do not silently concatenate unless that synthetic id is stable, documented, and actually unique. Prefer an upstream model that exposes a deliberate single-column id for the graph.
 - **No primary key** — usually an event, aggregate, or throwaway helper table. Confirm before modeling it as an entity.
+- **SCD2 / row-versioned dimensions** — if a dimension carries a surrogate row-version key (`*_KEY`), a stable business id, and effective/end-date columns, use the **surrogate `*_KEY` as `primary_id`** — that is the column fact tables join on; the business id is usually absent from facts. The graph includes every version row unless you filter to current rows (`is_current = true`) at the model layer, so unfiltered SCD2 entities over-count.
 - **Templated SQL in model sources** — render it with the current context before parsing columns; raw template text will miss projected fields.
-- **`snapshot_date` / `loaded_at` / `_etl_timestamp` columns** — *not* true event timestamps. They are warehouse metadata. Do not classify the source as an event unless a real business-time column exists.
+- **Ingestion-metadata timestamps (`snapshot_date` / `loaded_at` / `_etl_timestamp` / `created_at`)** — *not* true event timestamps. They record when the row was written, not when the business event happened. Do not classify the source as an event unless a real business-time column exists — and when one does (e.g. `event_at`, `ordered_at`), use it for the event's `timestamp`, never the ingestion column.
 - **Soft-deleted rows** — if the table has an `is_deleted` / `deleted_at` column, the Data Graph will include them unless filtered. Note this; the customer may want a filter at the model layer.
 - **Multi-tenant columns** — if the warehouse is multi-tenant (e.g., `tenant_id`), surface that column in the entity shape and call out scoping expectations.
 - **Audience wraps a model that joins multiple tables** — the model is the entity shape; the audience is just a saved filter on top. Use the model for the Data Graph node, not the base tables unless you are intentionally decomposing the model.
@@ -97,7 +98,7 @@ Every shortlisted source becomes one of:
 **One Data Graph per workspace / domain / warehouse account.** *Why:* cross-workspace joins are not supported, and mixing domains (e.g., Consumer + B2B) in one graph muddies the builder UX. Also, all models in a graph must resolve to the same warehouse account.
 
 **Entity selection:**
-- **Root entity** — the primary "who" being activated (users, branches, contacts).
+- **Root entity** — the primary "who" being activated (users, branches, contacts). Mark it in YAML with `root: true` on the entity model (entity-only field). **Multiple roots are valid** — each `root: true` entity is an independent audience-builder anchor, so a graph may have one or several. The validator does *not* enforce a count (zero, one, or many all pass), so set `root` deliberately on whichever entities the builder should start from rather than relying on a default.
 - **Related entities** — supporting objects with foreign-key relationships to the root.
 - **Events** — timestamped activity tables tied back to an entity.
 
@@ -105,6 +106,18 @@ Every shortlisted source becomes one of:
 - `source_join_key` is the column on the *current* model (the one declaring the relationship).
 - `target_join_key` is the column on the *target* model.
 - Cardinality describes how many target rows exist per source row: `branch → contacts` is `one-to-many` from the branch's perspective.
+- **Declare each relationship once, on one side only.** Do not also declare the inverse on the target model — the graph traverses it both ways. A double-declaration collides on `display_name` (which must be unique across all relationships) and inflates the relationship count.
+
+**Verify join keys before writing the YAML.** A wrong join key passes `validate` but silently returns the wrong audience population. If you have direct warehouse access (an MCP server, a CLI like `snowsql`/`bq`/`psql`, or an IDE connection), confirm every `source_join_key` and `target_join_key` exists on its table with one batched introspection query — RETL config alone does not catch typos or renamed columns:
+
+| Warehouse | One-shot query |
+|---|---|
+| Snowflake | `SELECT TABLE_NAME, COLUMN_NAME FROM <DB>.INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '<schema>' AND TABLE_NAME IN (...)` |
+| BigQuery | `SELECT table_name, column_name FROM <project>.<dataset>.INFORMATION_SCHEMA.COLUMNS WHERE table_name IN (...)` |
+| Postgres / Redshift | `SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = '<schema>' AND table_name IN (...)` |
+| Databricks | `SELECT table_name, column_name FROM system.information_schema.columns WHERE table_name IN (...)`, or `DESCRIBE TABLE <catalog>.<schema>.<table>` |
+
+If you have no warehouse access, fall back to the rule in **Validation & handoff**: flag every inferred join key and require confirmation before `apply`.
 
 **Minimal skeleton:**
 
@@ -227,6 +240,7 @@ Before handing the YAML to the customer:
 - **Soft-deleted rows** are included unless filtered at the model layer.
 - **Multi-tenant schemas** need the tenant column surfaced so Audiences can scope correctly.
 - **Device-mode destinations** bypass RudderStack servers; they will not explain warehouse-side RETL source shape.
+- **Date/time dimensions are not graph nodes.** Do not model `DIM_DATES` / `DIM_TIME` or join them at audience time. An event model's `timestamp` column already encodes the moment, and time-window filters operate on it directly.
 
 ---
 

--- a/plugins/rudder-core/skills/rudder-data-graphs/references/data-graph-yaml-template.md
+++ b/plugins/rudder-core/skills/rudder-data-graphs/references/data-graph-yaml-template.md
@@ -111,8 +111,8 @@ spec:
 - Entity→event cardinality must be `one-to-many`
 - Entity↔entity can be any cardinality
 - `target` must use URN syntax `#data-graph-model:<model-id>` and resolve to a model in the same spec
-- All `display_name` values must be unique across models and relationships
-- Declare each relationship **once, on a single model** — do not also declare its inverse on the target model; the graph traverses it both ways. Double-declaration collides on `display_name` and inflates the relationship count
+- `display_name` must be unique **among models** and, separately, **among relationships** — the two are independent namespaces, so a model and a relationship may share a name, but two models (or two relationships) may not
+- Declare each relationship **once, on a single model** — do not also declare its inverse on the target model; the graph traverses it both ways. Double-declaration collides on the relationship `display_name` and inflates the relationship count
 - `root: true` is an optional entity-only flag; multiple roots are allowed and the count is not validated
 
 ## Worked example: Property vertical
@@ -210,7 +210,7 @@ The `target` URN doesn't match any `id` in the same spec. Check for typos. Remem
 
 ### "Duplicate display_name"
 
-Two models or relationships have the same `display_name`. Each must be unique. This applies across ALL models and relationships in the spec.
+Two models share a `display_name`, or two relationships share one. Names must be unique **within each type** — model names among models, relationship names among relationships. (A model and a relationship may share a name; the namespaces are separate.)
 
 A common trigger is two relationships that naturally share a label — e.g. `sale-via-channel` and `interaction-via-channel` both wanting "Via Channel". Prefix with the source entity to disambiguate: "Sale Via Channel" and "Interaction Via Channel". The same fix applies to any pair of symmetric relationships pointing at the same target entity.
 

--- a/plugins/rudder-core/skills/rudder-data-graphs/references/data-graph-yaml-template.md
+++ b/plugins/rudder-core/skills/rudder-data-graphs/references/data-graph-yaml-template.md
@@ -22,6 +22,7 @@ spec:
       table: "ACME_DB.ECOMMERCE.DIM_CUSTOMERS"  # 3-part: catalog.schema.table
       description: "Customer records with demographics and loyalty tier"  # Tooltip in Audience Builder.
       primary_id: "CUSTOMER_KEY"         # Required for entity. Column that uniquely identifies rows.
+      root: true                         # Entity only. Marks an audience-builder anchor. Multiple roots allowed; count is not validated.
       relationships:
         # Entity → Event relationship
         - id: "customer-has-orders"
@@ -85,6 +86,7 @@ spec:
 | `table` | String | Yes | Fully qualified: `catalog.schema.table` |
 | `description` | String | No | Tooltip in Audience Builder |
 | `primary_id` | String | Entity only | Column that uniquely identifies rows |
+| `root` | Bool | Entity only, optional | Marks an audience-builder anchor. Multiple roots allowed; the count is not validated (zero, one, or many all pass) |
 | `timestamp` | String | Event only | Event timestamp column |
 | `relationships` | List | No | Relationships to other models |
 
@@ -110,6 +112,8 @@ spec:
 - Entity↔entity can be any cardinality
 - `target` must use URN syntax `#data-graph-model:<model-id>` and resolve to a model in the same spec
 - All `display_name` values must be unique across models and relationships
+- Declare each relationship **once, on a single model** — do not also declare its inverse on the target model; the graph traverses it both ways. Double-declaration collides on `display_name` and inflates the relationship count
+- `root: true` is an optional entity-only flag; multiple roots are allowed and the count is not validated
 
 ## Worked example: Property vertical
 
@@ -131,6 +135,7 @@ spec:
       table: "PROPCO_DW.ANALYTICS.DIM_BRANCH"
       description: "Property management branches"
       primary_id: "BRANCH_ID"
+      root: true
       relationships:
         - id: "branch-has-contacts"
           display_name: "Has Contacts"
@@ -206,6 +211,8 @@ The `target` URN doesn't match any `id` in the same spec. Check for typos. Remem
 ### "Duplicate display_name"
 
 Two models or relationships have the same `display_name`. Each must be unique. This applies across ALL models and relationships in the spec.
+
+A common trigger is two relationships that naturally share a label — e.g. `sale-via-channel` and `interaction-via-channel` both wanting "Via Channel". Prefix with the source entity to disambiguate: "Sale Via Channel" and "Interaction Via Channel". The same fix applies to any pair of symmetric relationships pointing at the same target entity.
 
 ### "Invalid table reference"
 


### PR DESCRIPTION
## Summary

Migrates reusable guidance that was surfaced while building an e-commerce data-graph end to end (build → validate → dry-run → apply against Snowflake) from a project-level `CLAUDE.md` into the upstream skills, so new IaC projects need less per-project documentation. All tool-behavior claims were verified against the `rudder-iac` source.

### `rudder-data-graphs`
- **`root` field documented** as an optional, entity-only flag. Multiple roots are valid and the validator does **not** enforce a count (zero/one/many all pass) — verified in `cli/internal/providers/datagraph/rules/datagraph_spec_valid.go`. Added to the annotated template, the model-fields table, the Property worked example, and the validation rules.
- **Relationship sidedness rule** — declare each relationship once, never the inverse on the target (double-declaration collides on `display_name` and inflates the count).
- **Join-key verification step** (Step 4) — warehouse-agnostic introspection queries (Snowflake / BigQuery / Postgres / Redshift / Databricks) to confirm join keys before writing YAML, with an explicit no-warehouse-access fallback.
- **New edge cases** — SCD2 surrogate-key `primary_id` selection, ingestion-metadata timestamps (incl. `created_at`), and a date-dimension (`DIM_DATES`/`DIM_TIME`) anti-pattern gotcha.
- **Symmetric `display_name` collision** fix in the template troubleshooting.

### `rudder-cli-workflow`
- **`--confirm=false`** documented for non-interactive apply. The default `--confirm=true` silently no-ops in non-TTY contexts (`PlainSyncReporter.AskConfirmation()` returns false) — verified in `cli/internal/syncer/reporters/plain.go`.
- **`apply` is full source of truth** callout in the dry-run step: any workspace resource of any kind absent from the project is deleted; there is no scoping flag (`apply` takes only `--location`, `--dry-run`, `--confirm`).
- **`-c <config>`** multi-environment guidance.
- **Fixed** the misleading "unexpected deletion → check metadata.import" troubleshooting row.

## Test plan
- [ ] Skim rendered Markdown for the three changed files
- [ ] Confirm the `root`/multi-root claim matches current `rudder-iac` validator behavior
- [ ] Confirm `--confirm` default and non-TTY behavior against the installed `rudder-cli` version
- [ ] Sanity-check the introspection queries for each warehouse dialect

🤖 Generated with [Claude Code](https://claude.com/claude-code)