### PR TITLE
docs: drop unsupported @<tag> pin claim

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Your PR description should include:
 
 - Plugin versions live in the **top-level `.claude-plugin/marketplace.json`**, not in individual `plugin.json` files.
 - Bump the relevant plugin's `version` field in `marketplace.json` when your change materially alters skill behavior. Minor content tweaks don't need a bump.
-- Tag releases (`git tag vX.Y.Z && git push --tags`) so users can pin with `@vX.Y.Z` when adding the marketplace.
+- Tag releases (`git tag vX.Y.Z && git push --tags`) for traceability and the GitHub releases UI. The Claude Code marketplace command installs from `main`; users who need to freeze a specific version can `git checkout` the tag manually in `~/.claude/plugins/marketplaces/rudderlabs-rudder-agent-skills`.
 
 ## Governance
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ claude plugin install rudder-core@rudder-agent-skills
 claude plugin install rudder-cli@rudder-agent-skills
 ```
 
-Pin to a release by appending `@v0.0.1` to the marketplace slug. Update later with `/plugin marketplace update rudder-agent-skills`.
+Update to the latest release with `/plugin marketplace update rudder-agent-skills`.
 
 ## Available skills
 


### PR DESCRIPTION
## Summary

`/plugin marketplace add rudderlabs/rudder-agent-skills@v0.0.1`
fails — the Claude Code marketplace command passes the whole
string to `git clone`, and GitHub rejects `@` in repo names. The
README + CONTRIBUTING.md both claimed this pin syntax worked;
it never did. The docs were aspirational from the initial setup
and got carried through the v0.0.1 release.

Surfaced by post-public smoke test:
```
/plugin marketplace add rudderlabs/rudder-agent-skills@v0.0.1
→ fatal: remote error: rudderlabs/rudder-agent-skills@v0.0.1 is
not a valid repository name
```


---

## Plugin(s) affected

- [x] Repo-wide (docs only — README, CONTRIBUTING)

---

## Changes

- `README.md` line 84 — drop the pin sentence; keep the
  update-to-latest guidance (`/plugin marketplace update`)
  which is supported.
- `CONTRIBUTING.md` line 124 — keep the tagging guidance
  (still valuable for GitHub releases UI and traceability),
  drop the false `@<tag>` pin claim, document the manual
  `git checkout` workaround for users who want to freeze
  a specific version.

No skill content changes. Linter unchanged.

---

## Skill testing

N/A — docs-only.

- Verified: `/plugin marketplace add rudderlabs/rudder-agent-skills`
  (without pin) works against the public repo.

---

## Risk / Impact

**Low.** Doc correction only.

---

## Checklist

- [x] Linter passes (no skill content changed)
- [x] No secrets, customer names, or internal URLs