### PR TITLE
docs: rudder-cli account lookup for Data Graph account_id

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Skills for working with RudderStack via CLI, MCP server, and Terraform.",
-    "version": "0.0.2"
+    "version": "0.0.3"
   },
   "plugins": [
     {
       "name": "rudder-core",
       "source": "./skills/rudder-core",
       "description": "Cross-tool RudderStack domain knowledge: data catalog, tracking plans, data graphs, instrumentation planning and debugging.",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "author": {
         "name": "RudderStack"
       },
@@ -28,7 +28,7 @@
       "name": "rudder-cli",
       "source": "./skills/rudder-cli",
       "description": "Workflows for driving the rudder-cli and rudder-typer CLIs: validate, dry-run, apply, import, transformations.",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "author": {
         "name": "RudderStack"
       },
@@ -43,7 +43,7 @@
       "name": "rudder-mcp",
       "source": "./skills/rudder-mcp",
       "description": "Workflows for RudderStack's MCP server at mcp.rudderstack.com: connect AI/LLM agents to a RudderStack workspace and drive it via MCP tool calls.",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "author": {
         "name": "RudderStack"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3] - 2026-06-03
+
 ### Changed
 
+- **`rudder-cli` / `rudder-cli-workflow`** — documented
+  `rudder-cli workspace accounts list` as the authoritative way to discover
+  workspace account IDs. Added a "Looking up account IDs" subsection covering
+  the mandatory `--json` flag in non-interactive contexts (plain output needs
+  a TTY), the meaningful fields (`id` is the value for a spec's `account_id`),
+  the `--category wht` / `--type` filters, and the note that this surfaces
+  accounts the MCP cannot (Data Graph UI / standalone warehouse connections).
+- **`rudder-core` / `rudder-data-graphs`** — reframed `account_id` resolution
+  around the CLI account list instead of requiring a RETL source config. Added
+  **Step 4a — Resolve the warehouse `account_id`** with a "building from
+  scratch / no RETL source yet" branch, a why-not-MCP note, and a
+  failed-apply-on-missing-`account_id` troubleshooting entry in the YAML
+  template.
+- **`rudder-mcp` / `rudder-mcp-workflow`** — added a "Don't do this" item:
+  don't rely on the MCP to discover account IDs (it only sees accounts behind
+  a RETL source or destination); fall back to
+  `rudder-cli workspace accounts list --category wht --json`.
 - **Breaking (repo layout):** renamed top-level `plugins/` directory to `skills/` so the [skills.sh](https://skills.sh) catalog indexer surfaces all 17 skills (it walks `skills/` but not `plugins/`). Each plugin still lives at `skills/<plugin>/skills/<skill>/SKILL.md`, mirroring the [`dbt-labs/dbt-agent-skills`](https://github.com/dbt-labs/dbt-agent-skills) layout. Marketplace manifest plugin `source` fields updated accordingly. The `npx skills add rudderlabs/rudder-agent-skills` install UX is unchanged.
+
+### Updating from a previous install
+
+Already installed `0.0.2` (or earlier)? Pull the new skill content:
+
+- **Vercel Skills CLI:** `npx skills update` (or `npx skills update rudder-cli-workflow rudder-data-graphs rudder-mcp-workflow` to update only the changed skills).
+- **Claude Code marketplace:** `/plugin marketplace update rudder-agent-skills`, then the updated `rudder-core`, `rudder-cli`, and `rudder-mcp` plugins are picked up automatically.
+- **Manual git clone:** `cd ~/.claude/plugins/marketplaces/rudder-agent-skills && git pull`.
 
 ## [0.0.2] - 2026-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   workspace account IDs. Added a "Looking up account IDs" subsection covering
   the mandatory `--json` flag in non-interactive contexts (plain output needs
   a TTY), the meaningful fields (`id` is the value for a spec's `account_id`),
-  the `--category wht` / `--type` filters, and the note that this surfaces
+  the `--category source` / `--type` filters, and the note that this surfaces
   accounts the MCP cannot (Data Graph UI / standalone warehouse connections).
 - **`rudder-core` / `rudder-data-graphs`** — reframed `account_id` resolution
   around the CLI account list instead of requiring a RETL source config. Added
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`rudder-mcp` / `rudder-mcp-workflow`** — added a "Don't do this" item:
   don't rely on the MCP to discover account IDs (it only sees accounts behind
   a RETL source or destination); fall back to
-  `rudder-cli workspace accounts list --category wht --json`.
+  `rudder-cli workspace accounts list --category source --json`.
 - **Breaking (repo layout):** renamed top-level `plugins/` directory to `skills/` so the [skills.sh](https://skills.sh) catalog indexer surfaces all 17 skills (it walks `skills/` but not `plugins/`). Each plugin still lives at `skills/<plugin>/skills/<skill>/SKILL.md`, mirroring the [`dbt-labs/dbt-agent-skills`](https://github.com/dbt-labs/dbt-agent-skills) layout. Marketplace manifest plugin `source` fields updated accordingly. The `npx skills add rudderlabs/rudder-agent-skills` install UX is unchanged.
 
 ### Updating from a previous install

--- a/skills/rudder-cli/skills/rudder-cli-workflow/SKILL.md
+++ b/skills/rudder-cli/skills/rudder-cli-workflow/SKILL.md
@@ -130,8 +130,8 @@ Each line is one account object. The fields that matter:
 Filter to narrow the list:
 
 ```bash
-# Warehouse connections only (what a Data Graph needs)
-rudder-cli workspace accounts list --category wht --json
+# RETL source warehouse accounts (what a Data Graph needs)
+rudder-cli workspace accounts list --category source --json
 
 # By engine
 rudder-cli workspace accounts list --type snowflake --json

--- a/skills/rudder-cli/skills/rudder-cli-workflow/SKILL.md
+++ b/skills/rudder-cli/skills/rudder-cli-workflow/SKILL.md
@@ -104,8 +104,40 @@ digraph workflow {
 | `rudder-cli apply -l ./` | Apply changes to workspace | After dry-run review |
 | `rudder-cli apply --confirm=false -l ./` | Apply without the interactive prompt | CI, piped output, agent contexts |
 | `rudder-cli plan -l ./` | Show detailed execution plan | Alternative to dry-run |
+| `rudder-cli workspace accounts list --json` | List workspace accounts (warehouse/source/etc.) and their IDs | Resolving an `account_id`/`accountId` for a resource spec |
 
 **Note:** `-l ./` specifies the project location (current directory).
+
+### Looking up account IDs
+
+Many resource specs reference a workspace account by id — e.g. a Data Graph's `spec.account_id` needs the warehouse account it runs against. Resolve it from the CLI rather than guessing:
+
+```bash
+# Always use --json in agent/non-interactive contexts.
+# The plain table output requires a TTY and fails with
+# "could not open a new TTY" when piped.
+rudder-cli workspace accounts list --json
+```
+
+Each line is one account object. The fields that matter:
+
+- **`id`** — this is the value to paste into `account_id` / `accountId` in a spec.
+- **`name`** — human label (e.g. `Snowflake`).
+- **`definition.category`** — account role: `wht` = warehouse connection, `source` = source connection, `profilesStore`, etc.
+- **`definition.type`** — engine: `snowflake`, `databricks`, `git`, …
+- **`options`** — connection details (`account`, `dbname`, `warehouse`, `schema`, `role`, `user`) to disambiguate when several accounts share a name.
+
+Filter to narrow the list:
+
+```bash
+# Warehouse connections only (what a Data Graph needs)
+rudder-cli workspace accounts list --category wht --json
+
+# By engine
+rudder-cli workspace accounts list --type snowflake --json
+```
+
+**This is the authoritative way to discover account IDs** — including accounts created through the Data Graph UI or a warehouse connection, which are *not* discoverable via `rudder-mcp` (the MCP only surfaces accounts reachable through a rETL source or destination). When working without a rETL source yet (e.g. building a workspace from scratch), `rudder-cli workspace accounts list` is the fallback the agent must use.
 
 **`-c <path>` selects the config (workspace + token).** Pass it explicitly if you maintain per-environment configs (e.g. `~/.rudder/dev.config.json`, `~/.rudder/prod.config.json`); without it, rudder-cli uses the default config that `rudder-cli auth login` last wrote. Verify the target with `rudder-cli workspace info -c <path>` before `apply`.
 

--- a/skills/rudder-core/skills/rudder-data-graphs/SKILL.md
+++ b/skills/rudder-core/skills/rudder-data-graphs/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: rudder-data-graphs
 description: Produces Data Graph YAML from RETL sources for Audiences. Use when designing Data Graphs, mapping RETL to entities/events, or assessing customer fit for Audiences.
+allowed-tools: "Bash(rudder-cli *), Read, Write, Edit"
 ---
 
 # RETL Connection Analysis & Data Graph Design
@@ -24,7 +25,7 @@ The end-to-end flow is: find workspaces → list RETL sources → shortlist rele
 1. `admin_search_organizations(company_name=...)` to get the `org_id`.
 2. `admin_search_workspaces(search_by=organizationId)` using that id.
 3. Keep only `status=ACTIVE` workspaces. *Why:* inactive workspaces often have stale or disconnected configs and will produce misleading source lists.
-4. Note the likely warehouse-backed workspaces, but **do not assume you already have the correct `accountId` at this stage**. *Why:* the Data Graph YAML embeds `account_id`, and that value is usually most reliable on the relevant RETL source config rather than on the workspace summary.
+4. Note the likely warehouse-backed workspaces, but **do not assume you already have the correct `accountId` at this stage**. *Why:* the Data Graph YAML embeds `account_id`, and that value is the warehouse account the graph runs against. The most authoritative source for it is `rudder-cli workspace accounts list --json` (see Step 4a); a RETL source config is a convenient secondary hint when one already exists, but it is not a prerequisite.
 
 ---
 
@@ -48,7 +49,7 @@ Run `list_sources(workspace_id=..., retl_type=all, includeConfig=false)` per wor
    - **Event candidates** — tables/models with a real business-time timestamp (`ordered_at`, `sent_at`, `opened_at`, etc.) and a clear relationship back to an entity. Pull these in; events are a major Data Graph unlock that audiences alone can't surface.
    - **FK targets** — tables/models referenced by foreign keys from anchor entities (e.g., if the anchor `contact` has a `branch_id`, pull in `branch`). Pull these in.
    - **Everything else** — keep in the Source Inventory for completeness, but do not force into the Data Graph unless it materially improves segmentation or the customer asks. Noise suppression matters on large workspaces.
-5. **Resolve `accountId` only after the shortlist exists.** Prefer the warehouse account id from the specific RETL source configs you are actually using in the graph. If shortlisted sources disagree on `accountId`, stop and flag it; one graph should not span multiple warehouse accounts.
+5. **Resolve `accountId` only after the shortlist exists.** Cross-check the warehouse account id from the specific RETL source configs you are actually using in the graph against `rudder-cli workspace accounts list` (see Step 4a). If shortlisted sources disagree on `accountId`, stop and flag it; one graph should not span multiple warehouse accounts.
 
 **What to extract, by sourceType:**
 
@@ -148,6 +149,34 @@ For vertical-specific starting shapes (Property / E-commerce / SaaS), read `refe
 
 ---
 
+## Step 4a — Resolve the warehouse `account_id`
+
+`spec.account_id` must be the id of the **warehouse account** the graph runs against. The account only needs to *exist* — it does not need to be selected in the Data Graph UI first, and you do not need a RETL source to obtain its id.
+
+**The authoritative lookup is the CLI:**
+
+```bash
+# --json is required in agent/non-interactive contexts; the plain
+# table output needs a TTY and fails when piped.
+rudder-cli workspace accounts list --category wht --json
+```
+
+Each line is an account object. Use the **`id`** field as `account_id`; use `name` and `options` (`account`, `dbname`, `warehouse`, `schema`) to pick the right one when several warehouse accounts exist. `--category wht` filters to warehouse connections; drop the filter or use `--type snowflake|databricks|...` to widen.
+
+**Why the CLI and not the MCP:** `rudder-mcp` can only locate accounts reachable through a **RETL source or a destination**. Accounts created through the **Data Graph UI** or a standalone **warehouse connection** are invisible to the MCP — but they *do* appear in `rudder-cli workspace accounts list`. When the MCP cannot surface the account, fall back to the CLI (or accept an `account_id` the user states explicitly).
+
+### Building from scratch — no RETL source yet
+
+Common for demo-environment builds (e.g. provisioning a workspace end-to-end before any audience or RETL source exists). There is no RETL source config to read the id from, and the obvious "create a dummy RETL source just to expose the account" step is unnecessary:
+
+1. Ensure the warehouse account exists (created via the dashboard, Terraform, or the Data Graph UI).
+2. `rudder-cli workspace accounts list --category wht --json` → take the matching `id`.
+3. Put that id in `spec.account_id` and proceed to validate / apply.
+
+> **Note:** creating a warehouse *destination* alone does not always surface a usable account id through every path. The reliable path in all cases is the CLI account list above.
+
+---
+
 ## Step 5 — Compile the demo warehouse spec
 
 For every model or table referenced in the Data Graph, produce:
@@ -234,7 +263,7 @@ Before handing the YAML to the customer:
 ## Common gotchas
 
 - **`includeConfig=false` is not enough** for audience extraction, SQL parsing, or `accountId` resolution. Always fetch full config for shortlisted sources.
-- **Warehouse account IDs** are most reliable on the RETL source configs you are actually using in the graph, not on a generic workspace summary.
+- **Warehouse account IDs** come from `rudder-cli workspace accounts list --category wht --json` (the `id` field). Don't require a RETL source to exist first, and don't rely on the MCP — it can't see DG-UI or warehouse-connection accounts. See Step 4a.
 - **Templated model SQL** must be rendered before column extraction.
 - **SQL parsing recovers names, not guaranteed types.** Mark unverifiable types as unknown / inferred.
 - **Soft-deleted rows** are included unless filtered at the model layer.

--- a/skills/rudder-core/skills/rudder-data-graphs/SKILL.md
+++ b/skills/rudder-core/skills/rudder-data-graphs/SKILL.md
@@ -158,10 +158,10 @@ For vertical-specific starting shapes (Property / E-commerce / SaaS), read `refe
 ```bash
 # --json is required in agent/non-interactive contexts; the plain
 # table output needs a TTY and fails when piped.
-rudder-cli workspace accounts list --category wht --json
+rudder-cli workspace accounts list --category source --json
 ```
 
-Each line is an account object. Use the **`id`** field as `account_id`; use `name` and `options` (`account`, `dbname`, `warehouse`, `schema`) to pick the right one when several warehouse accounts exist. `--category wht` filters to warehouse connections; drop the filter or use `--type snowflake|databricks|...` to widen.
+Each line is an account object. Use the **`id`** field as `account_id`; use `name` and `options` (`account`, `dbname`, `warehouse`, `schema`) to pick the right one when several accounts exist. `--category source` lists exactly the RETL-source warehouse accounts that are valid for a Data Graph; drop the filter or use `--type snowflake|databricks|...` to widen.
 
 **Why the CLI and not the MCP:** `rudder-mcp` can only locate accounts reachable through a **RETL source or a destination**. Accounts created through the **Data Graph UI** or a standalone **warehouse connection** are invisible to the MCP — but they *do* appear in `rudder-cli workspace accounts list`. When the MCP cannot surface the account, fall back to the CLI (or accept an `account_id` the user states explicitly).
 
@@ -170,7 +170,7 @@ Each line is an account object. Use the **`id`** field as `account_id`; use `nam
 Common for demo-environment builds (e.g. provisioning a workspace end-to-end before any audience or RETL source exists). There is no RETL source config to read the id from, and the obvious "create a dummy RETL source just to expose the account" step is unnecessary:
 
 1. Ensure the warehouse account exists (created via the dashboard, Terraform, or the Data Graph UI).
-2. `rudder-cli workspace accounts list --category wht --json` → take the matching `id`.
+2. `rudder-cli workspace accounts list --category source --json` → take the matching `id`.
 3. Put that id in `spec.account_id` and proceed to validate / apply.
 
 > **Note:** creating a warehouse *destination* alone does not always surface a usable account id through every path. The reliable path in all cases is the CLI account list above.
@@ -263,7 +263,7 @@ Before handing the YAML to the customer:
 ## Common gotchas
 
 - **`includeConfig=false` is not enough** for audience extraction, SQL parsing, or `accountId` resolution. Always fetch full config for shortlisted sources.
-- **Warehouse account IDs** come from `rudder-cli workspace accounts list --category wht --json` (the `id` field). Don't require a RETL source to exist first, and don't rely on the MCP — it can't see DG-UI or warehouse-connection accounts. See Step 4a.
+- **Warehouse account IDs** come from `rudder-cli workspace accounts list --category source --json` (the `id` field). Don't require a RETL source to exist first, and don't rely on the MCP — it can't see DG-UI or warehouse-connection accounts. See Step 4a.
 - **Templated model SQL** must be rendered before column extraction.
 - **SQL parsing recovers names, not guaranteed types.** Mark unverifiable types as unknown / inferred.
 - **Soft-deleted rows** are included unless filtered at the model layer.

--- a/skills/rudder-core/skills/rudder-data-graphs/references/data-graph-yaml-template.md
+++ b/skills/rudder-core/skills/rudder-data-graphs/references/data-graph-yaml-template.md
@@ -11,7 +11,7 @@ metadata:
   name: "acme-ecommerce-data-graph"      # Required. Human-readable name for the graph.
 spec:
   id: "acme-ecommerce-data-graph"        # Required. Unique identifier used in syncs.
-  account_id: "2abc123xyz"               # Required. Warehouse account ID from RETL source config.
+  account_id: "2abc123xyz"               # Required. Warehouse account ID. Resolve via `rudder-cli workspace accounts list --category wht --json` (the `id` field).
   models:
     # ─────────────────────────────────────────────────────────────
     # ENTITY: Root entity (the "who" being activated)
@@ -73,7 +73,7 @@ spec:
 | `kind` | String | Yes | Resource type: `"data-graph"` |
 | `metadata.name` | String | Yes | Human-readable name |
 | `spec.id` | String | Yes | Unique identifier for syncs |
-| `spec.account_id` | String | Yes | Warehouse account ID (from RETL source config) |
+| `spec.account_id` | String | Yes | Warehouse account ID — `rudder-cli workspace accounts list --category wht --json` (`id` field) |
 | `spec.models` | List | Yes | Entity and event models |
 
 ### Model fields
@@ -222,9 +222,22 @@ The `table` must be 3-part: `catalog.schema.table`. Common mistake: using 2-part
 
 Most likely cause: wrong join keys. The YAML is syntactically valid but semantically wrong. Verify join keys match actual FK relationships in the warehouse.
 
+### `apply` fails on a missing / invalid `account_id`
+
+The account only needs to *exist* — you do **not** need to select it in the Data Graph UI, and you do **not** need a RETL source. List the warehouse accounts and copy the `id`:
+
+```bash
+rudder-cli workspace accounts list --category wht --json
+```
+
+`rudder-mcp` cannot see accounts created through the DG UI or a standalone warehouse connection (it only surfaces accounts behind a RETL source or destination), so the CLI list is the authoritative lookup.
+
 ## CLI commands
 
 ```bash
+# List warehouse accounts; the `id` field is the spec.account_id value
+rudder-cli workspace accounts list --category wht --json
+
 # Validate all data-graph specs in current directory
 rudder-cli validate -l ./
 

--- a/skills/rudder-core/skills/rudder-data-graphs/references/data-graph-yaml-template.md
+++ b/skills/rudder-core/skills/rudder-data-graphs/references/data-graph-yaml-template.md
@@ -11,7 +11,7 @@ metadata:
   name: "acme-ecommerce-data-graph"      # Required. Human-readable name for the graph.
 spec:
   id: "acme-ecommerce-data-graph"        # Required. Unique identifier used in syncs.
-  account_id: "2abc123xyz"               # Required. Warehouse account ID. Resolve via `rudder-cli workspace accounts list --category wht --json` (the `id` field).
+  account_id: "2abc123xyz"               # Required. Warehouse account ID. Resolve via `rudder-cli workspace accounts list --category source --json` (the `id` field).
   models:
     # ─────────────────────────────────────────────────────────────
     # ENTITY: Root entity (the "who" being activated)
@@ -73,7 +73,7 @@ spec:
 | `kind` | String | Yes | Resource type: `"data-graph"` |
 | `metadata.name` | String | Yes | Human-readable name |
 | `spec.id` | String | Yes | Unique identifier for syncs |
-| `spec.account_id` | String | Yes | Warehouse account ID — `rudder-cli workspace accounts list --category wht --json` (`id` field) |
+| `spec.account_id` | String | Yes | Warehouse account ID — `rudder-cli workspace accounts list --category source --json` (`id` field) |
 | `spec.models` | List | Yes | Entity and event models |
 
 ### Model fields
@@ -227,7 +227,7 @@ Most likely cause: wrong join keys. The YAML is syntactically valid but semantic
 The account only needs to *exist* — you do **not** need to select it in the Data Graph UI, and you do **not** need a RETL source. List the warehouse accounts and copy the `id`:
 
 ```bash
-rudder-cli workspace accounts list --category wht --json
+rudder-cli workspace accounts list --category source --json
 ```
 
 `rudder-mcp` cannot see accounts created through the DG UI or a standalone warehouse connection (it only surfaces accounts behind a RETL source or destination), so the CLI list is the authoritative lookup.
@@ -236,7 +236,7 @@ rudder-cli workspace accounts list --category wht --json
 
 ```bash
 # List warehouse accounts; the `id` field is the spec.account_id value
-rudder-cli workspace accounts list --category wht --json
+rudder-cli workspace accounts list --category source --json
 
 # Validate all data-graph specs in current directory
 rudder-cli validate -l ./

--- a/skills/rudder-mcp/skills/rudder-mcp-workflow/SKILL.md
+++ b/skills/rudder-mcp/skills/rudder-mcp-workflow/SKILL.md
@@ -133,7 +133,7 @@ Workflow:
 
 - Don't run mutating tools (transformation upserts, destination connection changes, workspace switches) without confirming the target workspace and resource with the user — these affect shared workspace state.
 - Don't assume a specific tool name; the server evolves and your client's discovered tool list is the source of truth.
-- Don't rely on the MCP to discover workspace **account IDs**. The MCP only surfaces accounts reachable through a RETL source or a destination; accounts created through the Data Graph UI or a standalone warehouse connection are invisible to it. When you need an `account_id` (e.g. for a Data Graph's `spec.account_id`), fall back to the CLI: `rudder-cli workspace accounts list --category wht --json` (the `id` field).
+- Don't rely on the MCP to discover workspace **account IDs**. The MCP only surfaces accounts reachable through a RETL source or a destination; accounts created through the Data Graph UI or a standalone warehouse connection are invisible to it. When you need an `account_id` (e.g. for a Data Graph's `spec.account_id`), fall back to the CLI: `rudder-cli workspace accounts list --category source --json` (the `id` field).
 
 ## Credential Security
 

--- a/skills/rudder-mcp/skills/rudder-mcp-workflow/SKILL.md
+++ b/skills/rudder-mcp/skills/rudder-mcp-workflow/SKILL.md
@@ -133,6 +133,7 @@ Workflow:
 
 - Don't run mutating tools (transformation upserts, destination connection changes, workspace switches) without confirming the target workspace and resource with the user — these affect shared workspace state.
 - Don't assume a specific tool name; the server evolves and your client's discovered tool list is the source of truth.
+- Don't rely on the MCP to discover workspace **account IDs**. The MCP only surfaces accounts reachable through a RETL source or a destination; accounts created through the Data Graph UI or a standalone warehouse connection are invisible to it. When you need an `account_id` (e.g. for a Data Graph's `spec.account_id`), fall back to the CLI: `rudder-cli workspace accounts list --category wht --json` (the `id` field).
 
 ## Credential Security
 


### PR DESCRIPTION
## Summary

Teaches the skills to resolve a Data Graph's `spec.account_id` via `rudder-cli workspace accounts list` instead of assuming a RETL source config exists. This unblocks from-scratch demo builds (no RETL source yet) and documents that accounts created through the Data Graph UI or a standalone warehouse connection are invisible to `rudder-mcp`, so the agent must fall back to the CLI.

Motivated by a Slack thread: building demo envs end-to-end (Claude + skills, no MCP) hit a wall getting the warehouse `account_id` for the DG YAML. Confirmed `rudder-cli workspace accounts list` is the authoritative lookup (the `id` field is the `account_id`; `--json` is required in non-interactive contexts since plain output needs a TTY).

## Changes

- **`rudder-cli` / `rudder-cli-workflow`** — new "Looking up account IDs" subsection: the command, mandatory `--json`, the meaningful fields, `--category wht` / `--type` filters, and why this surfaces accounts the MCP can't.
- **`rudder-core` / `rudder-data-graphs`** — new **Step 4a — Resolve the warehouse `account_id`** with a "building from scratch / no RETL source yet" branch; reframed Step 1/2 account guidance; troubleshooting entry + lookup command in the YAML template. Added `allowed-tools` frontmatter (new fenced `bash` blocks otherwise trip linter W006).
- **`rudder-mcp` / `rudder-mcp-workflow`** — "Don't do this" item: don't rely on the MCP for account discovery; fall back to the CLI.
- **Versions:** marketplace + `rudder-core` + `rudder-cli` → `0.0.3`, `rudder-mcp` → `0.0.2`. CHANGELOG `[0.0.3]` entry includes update instructions for existing installs.

## Triggering prompts

**Should trigger** (`rudder-data-graphs` / `rudder-cli-workflow`):
> "Build a Data Graph for this workspace and apply it with rudder-cli — I don't have a RETL source yet, how do I get the account_id?"

**Should not trigger:**
> "How do I rotate my RudderStack access token?"

## Source

- `rudder-cli workspace accounts list --json` output validated locally (fields: `id`, `name`, `definition.category`/`type`, `options`).
- Data Graph YAML reference: https://www.rudderstack.com/docs/audiences/data-graph/cli-reference/

## Test plan

- [x] `python3 scripts/review-skills.py . --strict` → 0 errors, 0 warnings
- [ ] Smoke-install the marketplace locally and confirm the data-graphs / cli-workflow skills auto-invoke on the triggering prompt and recommend `rudder-cli workspace accounts list`
- [ ] `claude plugin validate .` in a clean env (failed locally due to an unrelated node `--enable-source-maps` issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)