### PR TITLE
feat(rudder-data-graphs): document per-column metadata (display_name + description)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Skills for working with RudderStack via CLI, MCP server, and Terraform.",
-    "version": "0.0.3"
+    "version": "0.0.4"
   },
   "plugins": [
     {
       "name": "rudder-core",
       "source": "./skills/rudder-core",
       "description": "Cross-tool RudderStack domain knowledge: data catalog, tracking plans, data graphs, instrumentation planning and debugging.",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "author": {
         "name": "RudderStack"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`rudder-core` / `rudder-data-graphs`** — documented the optional per-column
+  `columns:` block in the Data Graph YAML template: `display_name` (alias) and
+  `description` overrides that surface in the Audience Builder. Added a worked
+  `columns:` example to the annotated template, a `columns` row to the Model
+  fields table, a new **Column metadata fields** reference table, and validation
+  rules (sparse list; each entry needs `name` plus at least one of
+  `display_name` / `description`; alias is case-insensitive-unique per model).
+  Reframed the **Schema visibility** pitch in `capability-comparison.md` around
+  aliases/descriptions making raw warehouse columns marketer-readable.
+
 ## [0.0.3] - 2026-06-03
 
 ### Changed

--- a/skills/rudder-core/skills/rudder-data-graphs/references/capability-comparison.md
+++ b/skills/rudder-core/skills/rudder-data-graphs/references/capability-comparison.md
@@ -81,11 +81,11 @@ Use this to frame the upgrade conversation with customers.
 
 ### Schema visibility
 
-**Today:** Marketers see a list of columns. Relationships are invisible.
+**Today:** Marketers see a list of raw warehouse columns (`EMAIL_ADDRESS`, `CREATED_TS`). Relationships are invisible and column names are cryptic.
 
-**Upgrade:** Visual entity map shows how entities connect. Marketers understand the data model.
+**Upgrade:** Visual entity map shows how entities connect, and per-column **aliases** (`display_name`) and **descriptions** replace cryptic warehouse names with marketer-friendly labels right in the builder. Marketers understand the data model.
 
-**Example pitch:** "Less 'what column do I use?' tickets. The graph is self-documenting."
+**Example pitch:** "Less 'what column do I use?' tickets. The graph is self-documenting — `EMAIL_ADDRESS` shows up as 'Email' with a description, no warehouse spelunking."
 
 ---
 

--- a/skills/rudder-core/skills/rudder-data-graphs/references/data-graph-yaml-template.md
+++ b/skills/rudder-core/skills/rudder-data-graphs/references/data-graph-yaml-template.md
@@ -23,6 +23,14 @@ spec:
       description: "Customer records with demographics and loyalty tier"  # Tooltip in Audience Builder.
       primary_id: "CUSTOMER_KEY"         # Required for entity. Column that uniquely identifies rows.
       root: true                         # Entity only. Marks an audience-builder anchor. Multiple roots allowed; count is not validated.
+      columns:                           # Optional. Per-column overrides surfaced in the Audience Builder. Sparse — list only what you relabel.
+        - name: "EMAIL_ADDRESS"          # Warehouse column name (must match the table).
+          display_name: "Email"          # Alias shown instead of the raw column name. ≤255 chars, unique within the model.
+          description: "Primary contact email"  # Note shown alongside the column.
+        - name: "LOYALTY_TIER"
+          display_name: "Loyalty Tier"   # Alias only — no description.
+        - name: "CUSTOMER_NOTES"
+          description: "Free-form CRM notes"     # Description only — no alias.
       relationships:
         # Entity → Event relationship
         - id: "customer-has-orders"
@@ -89,6 +97,7 @@ spec:
 | `root` | Bool | Entity only, optional | Marks an audience-builder anchor. Multiple roots allowed; the count is not validated (zero, one, or many all pass) |
 | `timestamp` | String | Event only | Event timestamp column |
 | `relationships` | List | No | Relationships to other models |
+| `columns` | List | No | Per-column metadata overrides (aliases + descriptions) surfaced in the Audience Builder. See [Column metadata fields](#column-metadata-fields) |
 
 ### Relationship fields
 
@@ -100,6 +109,18 @@ spec:
 | `target` | String | Yes | Target model: `#data-graph-model:<model-id>` |
 | `source_join_key` | String | Yes | Column on source model for join |
 | `target_join_key` | String | Yes | Column on target model for join |
+
+### Column metadata fields
+
+Optional per-column overrides under a model's `columns:` block. **Sparse** — list only the columns you want to relabel; unlisted columns keep their raw warehouse names. By default the Audience Builder shows raw warehouse column names; aliases and descriptions make them readable for marketers building audiences and expressions.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | String | Yes | Warehouse column name (must match the model's `table`) |
+| `display_name` | String | Conditional | Alias shown in the Audience Builder instead of the raw column name. ≤255 chars, case-insensitive-unique within the model |
+| `description` | String | Conditional | Note shown alongside the column. ≤255 chars; no uniqueness constraint |
+
+Each `columns` entry must set **at least one** of `display_name` or `description` (an entry with only `name` is invalid). `apply` is declarative — drop a column's entry to clear its metadata.
 
 ## Validation rules
 
@@ -114,6 +135,9 @@ spec:
 - `display_name` must be unique **among models** and, separately, **among relationships** — the two are independent namespaces, so a model and a relationship may share a name, but two models (or two relationships) may not
 - Declare each relationship **once, on a single model** — do not also declare its inverse on the target model; the graph traverses it both ways. Double-declaration collides on the relationship `display_name` and inflates the relationship count
 - `root: true` is an optional entity-only flag; multiple roots are allowed and the count is not validated
+- `columns` is optional and **sparse** — list only the columns you want to relabel; unlisted columns keep their raw warehouse names
+- each `columns[]` entry needs `name` plus at least one of `display_name` / `description` (an entry with only `name` is invalid)
+- `columns[].display_name` is **case-insensitive-unique within a model** — a separate namespace from model and relationship `display_name` uniqueness; `description` has no uniqueness constraint
 
 ## Worked example: Property vertical
 


### PR DESCRIPTION
## What

Teaches the `rudder-core` / `rudder-data-graphs` skill about the new **Data Graph column metadata** feature so agents author it correctly: the optional per-column `columns:` block sets a marketer-friendly **alias** (`display_name`) and an optional **description**, both surfaced in the Audience & expression builder.

## Changes

`skills/rudder-core/skills/rudder-data-graphs/references/data-graph-yaml-template.md`
- Annotated template: worked `columns:` example on the `customers` entity (alias+description, alias-only, description-only)
- Model fields table: new `columns` row
- New **Column metadata fields** reference table (`name` / `display_name` / `description` + conditional/≤255/CI-unique rules)
- Validation rules: sparse list; each entry needs `name` + at least one of `display_name`/`description`; alias is case-insensitive-unique per model

`skills/rudder-core/skills/rudder-data-graphs/references/capability-comparison.md`
- Reframed the **Schema visibility** pitch around aliases/descriptions making raw warehouse columns marketer-readable

Housekeeping
- Bumped `rudder-core` (and marketplace) `0.0.3 → 0.0.4`; `CHANGELOG.md` entry under `[Unreleased]`

## Verification

`scripts/review-skills.py` → 0 errors, 0 warnings across 17 skills. `marketplace.json` validates as JSON.

> Companion user-facing docs PR: rudderlabs/rudder-hugo#2138

🤖 Generated with [Claude Code](https://claude.com/claude-code)