### PR TITLE
feat(rudder-data-graphs): document column PII masking (pii_mask)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Skills for working with RudderStack via CLI, MCP server, and Terraform.",
-    "version": "0.0.4"
+    "version": "0.0.5"
   },
   "plugins": [
     {
       "name": "rudder-core",
       "source": "./skills/rudder-core",
       "description": "Cross-tool RudderStack domain knowledge: data catalog, tracking plans, data graphs, instrumentation planning and debugging.",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "author": {
         "name": "RudderStack"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`rudder-core` / `rudder-data-graphs`** — documented the optional per-column
+  `pii_mask` flag in the Data Graph YAML template: `pii_mask: true` marks a
+  warehouse column as PII so its values are masked (`***`) in the Data Graph
+  preview (enterprise-only; server rejects it on other plans). Added it to the
+  annotated `columns:` example (including a PII-only entry with no alias), the
+  **Column metadata fields** table, and the validation rules (a column entry now
+  needs `name` plus at least one of `display_name` / `description` / `pii_mask`).
+  Extended the **Schema visibility** pitch in `capability-comparison.md` to note
+  PII columns stay masked in the preview.
+- **`rudder-core` / `rudder-data-graphs`** — documented the optional per-column
   `columns:` block in the Data Graph YAML template: `display_name` (alias) and
   `description` overrides that surface in the Audience Builder. Added a worked
   `columns:` example to the annotated template, a `columns` row to the Model

--- a/skills/rudder-core/skills/rudder-data-graphs/references/capability-comparison.md
+++ b/skills/rudder-core/skills/rudder-data-graphs/references/capability-comparison.md
@@ -83,7 +83,7 @@ Use this to frame the upgrade conversation with customers.
 
 **Today:** Marketers see a list of raw warehouse columns (`EMAIL_ADDRESS`, `CREATED_TS`). Relationships are invisible and column names are cryptic.
 
-**Upgrade:** Visual entity map shows how entities connect, and per-column **aliases** (`display_name`) and **descriptions** replace cryptic warehouse names with marketer-friendly labels right in the builder. Marketers understand the data model.
+**Upgrade:** Visual entity map shows how entities connect, and per-column **aliases** (`display_name`) and **descriptions** replace cryptic warehouse names with marketer-friendly labels right in the builder — and sensitive columns can be flagged **PII** (`pii_mask`) so their values are masked in the Data Graph preview. Marketers understand the data model, and PII stays protected.
 
 **Example pitch:** "Less 'what column do I use?' tickets. The graph is self-documenting — `EMAIL_ADDRESS` shows up as 'Email' with a description, no warehouse spelunking."
 

--- a/skills/rudder-core/skills/rudder-data-graphs/references/data-graph-yaml-template.md
+++ b/skills/rudder-core/skills/rudder-data-graphs/references/data-graph-yaml-template.md
@@ -23,14 +23,17 @@ spec:
       description: "Customer records with demographics and loyalty tier"  # Tooltip in Audience Builder.
       primary_id: "CUSTOMER_KEY"         # Required for entity. Column that uniquely identifies rows.
       root: true                         # Entity only. Marks an audience-builder anchor. Multiple roots allowed; count is not validated.
-      columns:                           # Optional. Per-column overrides surfaced in the Audience Builder. Sparse — list only what you relabel.
+      columns:                           # Optional. Per-column overrides surfaced in the Audience Builder. Sparse — list only what you relabel or flag.
         - name: "EMAIL_ADDRESS"          # Warehouse column name (must match the table).
           display_name: "Email"          # Alias shown instead of the raw column name. ≤255 chars, unique within the model.
           description: "Primary contact email"  # Note shown alongside the column.
+          pii_mask: true                 # Optional. Masks this column's values in the Data Graph preview. Enterprise only.
         - name: "LOYALTY_TIER"
           display_name: "Loyalty Tier"   # Alias only — no description.
         - name: "CUSTOMER_NOTES"
           description: "Free-form CRM notes"     # Description only — no alias.
+        - name: "SSN"
+          pii_mask: true                 # PII only — no alias or description needed.
       relationships:
         # Entity → Event relationship
         - id: "customer-has-orders"
@@ -97,7 +100,7 @@ spec:
 | `root` | Bool | Entity only, optional | Marks an audience-builder anchor. Multiple roots allowed; the count is not validated (zero, one, or many all pass) |
 | `timestamp` | String | Event only | Event timestamp column |
 | `relationships` | List | No | Relationships to other models |
-| `columns` | List | No | Per-column metadata overrides (aliases + descriptions) surfaced in the Audience Builder. See [Column metadata fields](#column-metadata-fields) |
+| `columns` | List | No | Per-column metadata overrides (aliases, descriptions, PII masking) surfaced in the Audience Builder. See [Column metadata fields](#column-metadata-fields) |
 
 ### Relationship fields
 
@@ -112,15 +115,16 @@ spec:
 
 ### Column metadata fields
 
-Optional per-column overrides under a model's `columns:` block. **Sparse** — list only the columns you want to relabel; unlisted columns keep their raw warehouse names. By default the Audience Builder shows raw warehouse column names; aliases and descriptions make them readable for marketers building audiences and expressions.
+Optional per-column overrides under a model's `columns:` block. **Sparse** — list only the columns you want to relabel or flag; unlisted columns keep their raw warehouse names. By default the Audience Builder shows raw warehouse column names; aliases and descriptions make them readable for marketers building audiences and expressions, and `pii_mask` flags sensitive columns so their values are masked in the Data Graph preview.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `name` | String | Yes | Warehouse column name (must match the model's `table`) |
 | `display_name` | String | Conditional | Alias shown in the Audience Builder instead of the raw column name. ≤255 chars, case-insensitive-unique within the model |
 | `description` | String | Conditional | Note shown alongside the column. ≤255 chars; no uniqueness constraint |
+| `pii_mask` | Bool | No | When `true`, masks the column's values (`***`) in the Data Graph preview. Defaults to `false`. **Enterprise only** — the server rejects `pii_mask: true` on other plans |
 
-Each `columns` entry must set **at least one** of `display_name` or `description` (an entry with only `name` is invalid). `apply` is declarative — drop a column's entry to clear its metadata.
+Each `columns` entry must set **at least one** of `display_name`, `description`, or `pii_mask` (an entry with only `name` is invalid). `apply` is declarative — drop a column's entry to clear its metadata. In the preview, masked values show as `***`; users with the **PII rETL Data Access** permission (or enterprise admins) can reveal the clear text.
 
 ## Validation rules
 
@@ -135,9 +139,10 @@ Each `columns` entry must set **at least one** of `display_name` or `description
 - `display_name` must be unique **among models** and, separately, **among relationships** — the two are independent namespaces, so a model and a relationship may share a name, but two models (or two relationships) may not
 - Declare each relationship **once, on a single model** — do not also declare its inverse on the target model; the graph traverses it both ways. Double-declaration collides on the relationship `display_name` and inflates the relationship count
 - `root: true` is an optional entity-only flag; multiple roots are allowed and the count is not validated
-- `columns` is optional and **sparse** — list only the columns you want to relabel; unlisted columns keep their raw warehouse names
-- each `columns[]` entry needs `name` plus at least one of `display_name` / `description` (an entry with only `name` is invalid)
+- `columns` is optional and **sparse** — list only the columns you want to relabel or flag; unlisted columns keep their raw warehouse names
+- each `columns[]` entry needs `name` plus at least one of `display_name` / `description` / `pii_mask` (an entry with only `name` is invalid)
 - `columns[].display_name` is **case-insensitive-unique within a model** — a separate namespace from model and relationship `display_name` uniqueness; `description` has no uniqueness constraint
+- `columns[].pii_mask` is an optional boolean (default `false`); marking a column `pii_mask: true` is **enterprise-only** and the server rejects it on other plans
 
 ## Worked example: Property vertical
 


### PR DESCRIPTION
## What

Teaches the `rudder-core` / `rudder-data-graphs` skill about the new per-column **`pii_mask`** flag so agents author it correctly. Setting `pii_mask: true` on a `columns:` entry marks a warehouse column as PII so its values are **masked (`***`) in the Data Graph preview**. Marking PII is **enterprise-only** (the server rejects it on other plans), and users with the **PII rETL Data Access** permission (or enterprise admins) can reveal the clear text. Builds on the column-metadata work in #16 (`display_name` + `description`).

Mirrors rudder-specs [#64](https://github.com/rudderlabs/rudder-specs/pull/64).

## Changes

`skills/rudder-core/skills/rudder-data-graphs/references/data-graph-yaml-template.md`
- Annotated template: `pii_mask: true` added to the `customers` `columns:` block, plus a PII-only entry (`SSN`, no alias/description)
- Model fields table: `columns` row now mentions PII masking
- **Column metadata fields** table: new `pii_mask` row; the "at least one of" rule now includes `pii_mask`; note on preview masking + the reveal permission
- Validation rules: new `pii_mask` rule (optional bool, default `false`, enterprise-only) and the updated at-least-one-of rule

`skills/rudder-core/skills/rudder-data-graphs/references/capability-comparison.md`
- Extended the **Schema visibility** pitch to note sensitive columns can be flagged PII and masked in the preview

Housekeeping
- Bumped `rudder-core` (and marketplace) `0.0.4 → 0.0.5`; `CHANGELOG.md` entry under `[Unreleased]`

## Verification

`scripts/review-skills.py .` → 0 errors, 0 warnings across 17 skills. `marketplace.json` validates as JSON.

> Companion user-facing docs PR: rudderlabs/rudder-hugo#2151

🤖 Generated with [Claude Code](https://claude.com/claude-code)