### PR TITLE
fix: add .cursor-plugin/marketplace.json for cursor.directory submission

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,83 @@
+{
+  "name": "rudder-agent-skills",
+  "owner": {
+    "name": "RudderStack",
+    "email": "no-reply@rudderstack.com"
+  },
+  "metadata": {
+    "description": "Skills for working with RudderStack via CLI, MCP server, Terraform, and Profiles workflows.",
+    "version": "0.0.5"
+  },
+  "plugins": [
+    {
+      "name": "rudder-core",
+      "source": "./skills/rudder-core",
+      "description": "Cross-tool RudderStack domain knowledge: data catalog, tracking plans, data graphs, instrumentation planning, instrumentation debugging, and destination delivery debugging.",
+      "author": {
+        "name": "RudderStack"
+      },
+      "homepage": "https://www.rudderstack.com/",
+      "repository": "https://github.com/rudderlabs/rudder-agent-skills",
+      "license": "MIT",
+      "category": "devtools",
+      "keywords": ["rudderstack", "instrumentation", "tracking-plan", "data-catalog", "data-graph", "destination-debugging"],
+      "tags": ["rudderstack", "domain"]
+    },
+    {
+      "name": "rudder-cli",
+      "source": "./skills/rudder-cli",
+      "description": "Workflows for driving the rudder-cli and rudder-typer CLIs: validate, dry-run, apply, import, transformations.",
+      "author": {
+        "name": "RudderStack"
+      },
+      "homepage": "https://github.com/rudderlabs/rudder-iac",
+      "repository": "https://github.com/rudderlabs/rudder-agent-skills",
+      "license": "MIT",
+      "category": "devtools",
+      "keywords": ["rudderstack", "rudder-cli", "rudder-typer", "cli", "devtools"],
+      "tags": ["rudderstack", "cli"]
+    },
+    {
+      "name": "rudder-mcp",
+      "source": "./skills/rudder-mcp",
+      "description": "Workflows for RudderStack's MCP server at mcp.rudderstack.com: connect AI/LLM agents to a RudderStack workspace and drive it via MCP tool calls.",
+      "author": {
+        "name": "RudderStack"
+      },
+      "homepage": "https://mcp.rudderstack.com/docs",
+      "repository": "https://github.com/rudderlabs/rudder-agent-skills",
+      "license": "MIT",
+      "category": "devtools",
+      "keywords": ["rudderstack", "mcp", "mcp-server", "ai-agent"],
+      "tags": ["rudderstack", "mcp"]
+    },
+    {
+      "name": "rudder-terraform",
+      "source": "./skills/rudder-terraform",
+      "description": "Workflows for managing RudderStack with the Terraform provider: provider setup, resource/data-source usage, and plan/apply cycles.",
+      "author": {
+        "name": "RudderStack"
+      },
+      "homepage": "https://github.com/rudderlabs/terraform-provider-rudderstack",
+      "repository": "https://github.com/rudderlabs/rudder-agent-skills",
+      "license": "MIT",
+      "category": "devtools",
+      "keywords": ["rudderstack", "terraform", "iac", "hcl"],
+      "tags": ["rudderstack", "terraform"]
+    },
+    {
+      "name": "rudder-profiles",
+      "source": "./skills/rudder-profiles",
+      "description": "Workflows for building RudderStack Profiles projects: setup, project creation, project analysis, controlled updates, and debugging.",
+      "author": {
+        "name": "RudderStack"
+      },
+      "homepage": "https://github.com/rudderlabs/profiles-mcp",
+      "repository": "https://github.com/rudderlabs/rudder-agent-skills",
+      "license": "MIT",
+      "category": "devtools",
+      "keywords": ["rudderstack", "profiles", "profile-builder", "identity-resolution", "feature-engineering"],
+      "tags": ["rudderstack", "profiles"]
+    }
+  ]
+}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -65,16 +65,22 @@ EOF
     fi
 fi
 
-# 3. Keep the Claude Code marketplace shim derived from the canonical manifest.
-#    Canonical: marketplace.json (Open Plugins / Cursor, repo root).
-#    Derived:   .claude-plugin/marketplace.json (Claude Code reads only this path).
-#    Edit the canonical file only — this regenerates and stages the shim.
+# 3. Keep the per-tool marketplace shims derived from the canonical manifest.
+#    Canonical: marketplace.json (Open Plugins standard, repo root).
+#    Derived:   .claude-plugin/marketplace.json (Claude Code reads only this path),
+#               .cursor-plugin/marketplace.json (cursor.directory reads only this path).
+#    Edit the canonical file only — this regenerates and stages the shims.
 CANON="${REPO_ROOT}/marketplace.json"
-SHIM="${REPO_ROOT}/.claude-plugin/marketplace.json"
-if [[ -f "$CANON" ]] && ! cmp -s "$CANON" "$SHIM"; then
-    cp "$CANON" "$SHIM"
-    git add "$SHIM"
-    echo "pre-commit: regenerated .claude-plugin/marketplace.json from marketplace.json (staged)." >&2
+if [[ -f "$CANON" ]]; then
+    for SHIM in "${REPO_ROOT}/.claude-plugin/marketplace.json" \
+                "${REPO_ROOT}/.cursor-plugin/marketplace.json"; do
+        if ! cmp -s "$CANON" "$SHIM" 2>/dev/null; then
+            mkdir -p "$(dirname "$SHIM")"
+            cp "$CANON" "$SHIM"
+            git add "$SHIM"
+            echo "pre-commit: regenerated ${SHIM#"$REPO_ROOT"/} from marketplace.json (staged)." >&2
+        fi
+    done
 fi
 
 # 4. Merge conflict markers in staged content.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,12 +38,15 @@ jobs:
             python3 -c "import json; json.load(open('$f'))" || exit 1
           done
 
-      - name: Marketplace shim in sync
+      - name: Marketplace shims in sync
         run: |
-          # .claude-plugin/marketplace.json (Claude Code) is derived from the canonical
-          # root marketplace.json (Open Plugins / Cursor). The pre-commit hook regenerates it.
-          cmp -s marketplace.json .claude-plugin/marketplace.json \
-            || { echo "::error::.claude-plugin/marketplace.json is stale — run: cp marketplace.json .claude-plugin/marketplace.json"; exit 1; }
+          # The per-tool shims are derived from the canonical root marketplace.json
+          # (Open Plugins standard). Claude Code reads .claude-plugin/, cursor.directory
+          # reads .cursor-plugin/. The pre-commit hook regenerates both.
+          for shim in .claude-plugin/marketplace.json .cursor-plugin/marketplace.json; do
+            cmp -s marketplace.json "$shim" \
+              || { echo "::error::$shim is stale — run: cp marketplace.json $shim"; exit 1; }
+          done
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,11 @@ Your PR description should include:
 ## Versioning & release
 
 - **Each plugin's version is single-sourced in its own `skills/<plugin>/.claude-plugin/plugin.json`.** Bump it there when your change materially alters skill behavior; minor content tweaks don't need a bump. (Both the Open Plugin standard and Claude Code read the version from `plugin.json` — for Claude it silently overrides any marketplace entry, so the marketplace files deliberately carry no per-plugin `version`.)
-- **The marketplace manifest has one canonical copy: `marketplace.json` at the repo root** (the vendor-neutral Open Plugins / Cursor location). `.claude-plugin/marketplace.json` is a byte-for-byte derived copy that only Claude Code reads — **never edit it by hand.** The pre-commit hook regenerates and stages it from the root file; CI fails if they drift (`cmp`). The repo-root file's top-level `metadata.version` is the marketplace catalog's own version.
+- **The marketplace manifest has one canonical copy: `marketplace.json` at the repo root** (the vendor-neutral Open Plugins location). Two byte-for-byte derived copies exist because each tool reads a different path and *only* that path — **never edit them by hand:**
+  - `.claude-plugin/marketplace.json` — Claude Code (`/plugin marketplace add`).
+  - `.cursor-plugin/marketplace.json` — cursor.directory submission (its parser checks only this path).
+
+  The pre-commit hook regenerates and stages both from the root file; CI fails if either drifts (`cmp`). The repo-root file's top-level `metadata.version` is the marketplace catalog's own version.
 - Tag releases (`git tag vX.Y.Z && git push --tags`) for traceability and the GitHub releases UI. The Claude Code marketplace command installs from `main`; users who need to freeze a specific version can `git checkout` the tag manually in `~/.claude/plugins/marketplaces/rudderlabs-rudder-agent-skills`.
 
 ## Governance


### PR DESCRIPTION
## Why #20 wasn't enough

After #20 added the root `marketplace.json`, submitting the repo to `cursor.directory/plugins/new` **still** failed with:

> No plugin components found in: repo root. We looked for: rules/*.mdc, .mcp.json or mcp.json, skills/*/SKILL.md, ...

I traced this to cursor.directory's actual resolver, [`cursor/community-plugins` → `apps/cursor/src/lib/github-plugin/parse.ts`](https://github.com/cursor/community-plugins/blob/main/apps/cursor/src/lib/github-plugin/parse.ts). Its `rootManifestPaths` checks for a marketplace manifest at **exactly one location**:

```
.plugin/plugin.json
.cursor-plugin/plugin.json
.claude-plugin/plugin.json
.cursor-plugin/marketplace.json   ← the only marketplace path it reads
```

It never reads root `marketplace.json` (the Open Plugins standard location) or `.claude-plugin/marketplace.json` (Claude Code). Its fallback sub-plugin detection scans for `<dir>/.cursor-plugin/plugin.json`, which we also don't have. With no marketplace detected, it scanned the repo root as a single plugin — and our skills live at `skills/<plugin>/skills/<skill>/SKILL.md`, not `skills/*/SKILL.md` at root.

## Fix

- Add **`.cursor-plugin/marketplace.json`** — a third byte-identical derived copy of the canonical root `marketplace.json`. This is the only path cursor.directory's parser reads.
- Extend the pre-commit hook and CI `cmp` check to keep **both** shims (`.claude-plugin/` + `.cursor-plugin/`) in sync with the canonical root file. Single authored source unchanged.
- Document the two derived copies in `CONTRIBUTING.md`.

## Verification

Replayed `parse.ts`'s logic against the tree: the manifest's `plugins[].source` entries resolve each plugin dir, and the regex `^<source>/skills/[^/]+/SKILL.md$` matches our nested skills — **23 skills** discovered across the 5 plugins (was 0).

| Plugin | Skills found |
|---|---|
| rudder-core | 9 |
| rudder-cli | 5 |
| rudder-mcp | 2 |
| rudder-terraform | 2 |
| rudder-profiles | 5 |

Also: all three manifests byte-identical; linter passes `--strict`.

## Manifest locations, final state

| Reader | Path |
|---|---|
| Open Plugins standard (canonical, authored) | `marketplace.json` |
| Claude Code | `.claude-plugin/marketplace.json` (derived) |
| cursor.directory | `.cursor-plugin/marketplace.json` (derived) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)