### PR TITLE
feat(rudder-cli): add rudder-resource-verbs skill

### DIFF
--- a/plugins/rudder-cli/skills/rudder-resource-verbs/SKILL.md
+++ b/plugins/rudder-cli/skills/rudder-resource-verbs/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: rudder-resource-verbs
+description: Inspect, adopt, and delete individual RudderStack resources with rudder-cli get / describe / delete / set-external-id and the scoped apply -f mode. Use when the user wants to list or show remote resources, export one as re-appliable YAML, adopt an unmanaged resource, or delete a single resource.
+allowed-tools: "Bash(rudder-cli *), Read, Write, Edit"
+---
+
+# Rudder CLI resource verbs (kubectl-style)
+
+A live, per-resource verb layer over RudderStack resources — the imperative
+counterpart to the declarative `validate → apply` cycle (see
+`rudder-cli-workflow`). Use these to **look at**, **adopt**, or **remove one**
+remote resource, and to apply **only specific files** without pruning the rest of
+the workspace.
+
+```
+get <type> [<id>]                 list, show one, or export a re-appliable spec
+describe <type> <id>              human-readable layout of one resource
+set-external-id <type> <rid> <x>  adopt an unmanaged remote resource into IaC
+delete <type> <id>                imperative remote delete of a managed resource
+apply -f <file|dir>…              scoped, delete-free apply (never prunes)
+```
+
+## Experimental — enable once
+
+This suite is gated behind an experimental flag. If a verb errors with
+"…are experimental; enable them with…", run:
+
+```bash
+rudder-cli experimental enable resourceCommands
+```
+
+(or set `RUDDERSTACK_CLI_EXPERIMENTAL=true` and `RUDDERSTACK_X_RESOURCE_COMMANDS=true`
+for a single invocation). Everything below assumes it is enabled and that
+`rudder-cli` is authenticated (`rudder-cli workspace info`).
+
+## When to reach for these vs the apply cycle
+
+```dot
+digraph pick {
+  rankdir=TB;
+  "What do you need?" [shape=diamond];
+  "See what exists / inspect one" [shape=box];
+  "Manage the whole project declaratively" [shape=box];
+  "Change just a few resources" [shape=box];
+  "Bring an existing dashboard-made resource under IaC" [shape=box];
+  "Remove one resource now" [shape=box];
+
+  "get / describe / get -o yaml" [shape=box];
+  "rudder-cli-workflow: validate -> apply --location" [shape=box];
+  "apply -f <files> (scoped, never deletes)" [shape=box];
+  "set-external-id" [shape=box];
+  "delete" [shape=box];
+
+  "What do you need?" -> "See what exists / inspect one" -> "get / describe / get -o yaml";
+  "What do you need?" -> "Manage the whole project declaratively" -> "rudder-cli-workflow: validate -> apply --location";
+  "What do you need?" -> "Change just a few resources" -> "apply -f <files> (scoped, never deletes)";
+  "What do you need?" -> "Bring an existing dashboard-made resource under IaC" -> "set-external-id";
+  "What do you need?" -> "Remove one resource now" -> "delete";
+}
+```
+
+**Mental model:** `get`/`describe` are live reads (snappy, no local project needed).
+`delete` and `set-external-id` are direct single-resource mutations. `apply -f`
+reuses the normal apply planner but **scopes to the files you pass**, so it only
+creates/updates and never deletes anything outside them — unlike
+`apply --location`, which reconciles the whole project and can prune.
+
+## Addressing a resource
+
+`<type>` is the registry type string, e.g. `event-stream-source`,
+`retl-source-sql-model`, `tracking-plan`, `account`. `<id>` resolves
+**external-id first, then remote-id**. Unknown types error with the full valid
+list; capability-unsupported verbs error clearly (e.g. `account` is read-only).
+
+## get — discover and export
+
+```bash
+rudder-cli get event-stream-source                      # list (table)
+rudder-cli get event-stream-source --managed            # only IaC-managed
+rudder-cli get event-stream-source --unmanaged          # only upstream-only
+rudder-cli get tracking-plan -l name="Checkout Plan"    # label selector
+rudder-cli get event-stream-source my-source -o yaml    # re-appliable spec
+rudder-cli get event-stream-source --managed -o json    # machine-readable list
+```
+
+The list columns are `EXTERNAL-ID · REMOTE-ID · NAME · MANAGED`. **`MANAGED=yes`
+means the resource has an external id (IaC-tracked); `no` means it exists only in
+the workspace** (e.g. created in the dashboard). `-o yaml` on a single resource
+emits a spec that round-trips through `apply -f` — see
+`references/round-trip-and-adoption.md`.
+
+## describe — read one resource
+
+```bash
+rudder-cli describe event-stream-source my-source
+```
+
+A templated layout of the same spec `get -o yaml` produces, plus a `Managed`
+line. Use it to explain a resource to a human; use `-o yaml`/`-o json` when you
+need to parse or re-apply it.
+
+## apply -f — scoped, delete-free changes
+
+```bash
+rudder-cli apply -f sources/orders.yaml --dry-run --confirm=false   # preview
+rudder-cli apply -f sources/orders.yaml --confirm=false             # apply
+rudder-cli apply -f sources/ -f tracking-plans/ --confirm=false     # multiple
+```
+
+- **`-f` never deletes** resources outside the given files — safe for targeted
+  edits. `--location` (whole-project reconcile) can delete; the two are mutually
+  exclusive.
+- Always `--dry-run` first and read the plan. In agent/non-interactive contexts
+  pass `--confirm=false` (the default prompt auto-declines when there's no TTY and
+  nothing is applied, silently).
+- Each `-f` path is validated independently; pass non-overlapping sets.
+
+## set-external-id — adopt an unmanaged resource
+
+```bash
+# 1) find the unmanaged one (MANAGED=no, blank external id)
+rudder-cli get event-stream-source --unmanaged
+# 2) claim it by remote id, giving it the external id IaC will use
+rudder-cli set-external-id event-stream-source <remote-id> orders-pipeline
+```
+
+After this the resource is `MANAGED=yes` and can be exported (`get -o yaml`),
+`apply -f`-managed, or `delete`d. Only types whose provider supports it accept
+`set-external-id`; others (e.g. `account`) refuse. See
+`references/round-trip-and-adoption.md`.
+
+## delete — remove one managed resource
+
+```bash
+rudder-cli delete event-stream-source my-source            # prompts to confirm
+rudder-cli delete event-stream-source my-source --confirm  # skip the prompt
+```
+
+Deletes a **managed** resource (one with an external id) from the remote
+workspace. Unmanaged resources are rejected — adopt them with `set-external-id`
+first if you truly mean to remove them via IaC. `delete` is real and immediate;
+prefer previewing with `get`/`describe` before removing.
+
+## Safety checklist (agents)
+
+- Confirm the target workspace first: `rudder-cli workspace info`.
+- Read-only verbs (`get`, `describe`) are always safe. `delete`, `set-external-id`,
+  and non-dry-run `apply -f` mutate the real workspace.
+- Prefer `apply -f` over `apply --location` when the intent is "change these
+  specific things" — it can't prune unrelated resources.
+- In non-interactive runs, pass `--confirm=false` (apply) / `--confirm` (delete),
+  or the operation silently no-ops on the auto-declined prompt.
+
+## Coverage
+
+`get` / `describe` / `-o yaml|json` work across registered types. Full mutate
+support (`apply -f`, `delete`, `set-external-id`) is verified for
+`event-stream-source` and `retl-source-sql-model`; other types offer whatever
+their provider implements and refuse the rest with a clear error.

--- a/plugins/rudder-cli/skills/rudder-resource-verbs/references/round-trip-and-adoption.md
+++ b/plugins/rudder-cli/skills/rudder-resource-verbs/references/round-trip-and-adoption.md
@@ -1,0 +1,77 @@
+# Round-trip and adoption patterns
+
+Deeper patterns for `get -o yaml` + `apply -f` and for adopting unmanaged
+resources with `set-external-id`. Load this when a task needs the exact flow.
+
+## The get -o yaml → apply -f round-trip
+
+`rudder-cli get <type> <id> -o yaml` emits the **same re-appliable spec** that
+`apply -f` consumes. So exporting and re-applying an unchanged resource is a
+no-op — which makes it a safe, drift-free way to edit one resource:
+
+```bash
+# 1. Export the live resource to a file
+rudder-cli get event-stream-source orders -o yaml > sources/orders.yaml
+
+# 2. Re-applying it unchanged shows no changes
+rudder-cli apply -f sources/orders.yaml --dry-run --confirm=false
+#   -> "No changes to apply"
+
+# 3. Edit a field, then apply just this file (scoped, never deletes)
+#    (change spec.name, a governance/tracking-plan ref, etc.)
+rudder-cli apply -f sources/orders.yaml --dry-run --confirm=false   # review the diff
+rudder-cli apply -f sources/orders.yaml --confirm=false             # apply
+```
+
+Why this beats hand-writing YAML: the exported spec already has the exact
+shape, ids, and any import metadata the server expects, so the first re-apply is
+guaranteed clean and every subsequent diff is exactly your edit.
+
+**Limitation.** Single-resource export loads only the target's own provider, so a
+cross-provider reference (e.g. an event-stream source pointing at a tracking plan
+owned by another provider) may not fully resolve in the emitted YAML. For those,
+manage the resources together through the normal project apply cycle
+(`rudder-cli-workflow`) instead.
+
+## Adopting an unmanaged resource
+
+A resource created outside IaC (e.g. in the dashboard) has **no external id** —
+it shows `MANAGED=no` with a blank `EXTERNAL-ID`. `set-external-id` associates it
+with a local external id, bringing it under IaC management without recreating it.
+
+```bash
+# 1. Find it — note the REMOTE-ID column
+rudder-cli get event-stream-source --unmanaged
+# EXTERNAL-ID  REMOTE-ID                    NAME                  MANAGED
+#              2Is8tBS8zFG3ensBtLT7ZN7BFuB  Legacy Orders Source  no
+
+# 2. Claim it: <type> <remote-id> <new-external-id>
+rudder-cli set-external-id event-stream-source 2Is8tBS8zFG3ensBtLT7ZN7BFuB orders-pipeline
+
+# 3. It is now managed and addressable by its external id
+rudder-cli get event-stream-source orders-pipeline
+rudder-cli get event-stream-source orders-pipeline -o yaml > sources/orders.yaml
+```
+
+From here it behaves like any managed resource: export it, keep it in your
+project, `apply -f` edits, or `delete` it.
+
+Notes:
+- Adoption is a one-way claim — there is no CLI "un-manage". Once adopted, a
+  whole-project `apply --location` that lacks the resource in local specs would
+  delete it; keep adopted resources in your project (or use scoped `apply -f`).
+- Capability-gated: only providers that expose a setter accept `set-external-id`.
+  Read-only types like `account` refuse it.
+
+## Wiring a delete safely
+
+```bash
+# Inspect before removing
+rudder-cli describe event-stream-source orders-pipeline
+# Remove (managed resources only; unmanaged are rejected)
+rudder-cli delete event-stream-source orders-pipeline --confirm
+```
+
+If `delete` reports the resource is unmanaged, it has no external id — adopt it
+with `set-external-id` first if IaC-managed deletion is really intended, or remove
+it in the dashboard.


### PR DESCRIPTION
## Summary

Adds a new skill, **`rudder-resource-verbs`**, teaching agents the experimental kubectl-style verb layer in `rudder-cli`: `get` / `describe` / `delete` / `set-external-id` and the scoped, delete-free `apply -f` mode, plus accounts as a read resource.

It's the imperative, per-resource counterpart to the existing declarative `rudder-cli-workflow` (validate → apply). The skill covers when to reach for each verb vs the apply cycle, addressing (external-id first, remote-id fallback), the experimental `resourceCommands` flag, the `get -o yaml | apply -f` round-trip, adopting unmanaged resources, capability gating, and agent safety (dry-run, `--confirm`).

Companion to rudder-iac PR [#633](https://github.com/rudderlabs/rudder-iac/pull/633), which introduces these verbs.

---

## Plugin(s) affected

- [ ] rudder-core
- [x] rudder-cli
- [ ] rudder-mcp
- [ ] rudder-terraform
- [ ] Repo-wide (CI, scripts, docs)

---

## Changes

- `plugins/rudder-cli/skills/rudder-resource-verbs/SKILL.md` — new skill (lean body: decision diagram, per-verb usage, experimental-flag note, safety checklist, coverage)
- `plugins/rudder-cli/skills/rudder-resource-verbs/references/round-trip-and-adoption.md` — deep-dive: `get -o yaml` → `apply -f` round-trip and `set-external-id` adoption

---

## Skill testing

- **Prompt that should trigger:** "Show me the event-stream sources in my RudderStack workspace and export one as YAML" · "Adopt this dashboard-created source into IaC" · "Delete just this one tracking plan"
- **Prompt that should NOT trigger:** "Write a JavaScript transformation that hashes emails" (→ `rudder-transformations`) · "Reconcile my whole catalog project" (→ `rudder-cli-workflow`)
- **Linter passes:** `python3 scripts/review-skills.py . --strict` → 0 findings for this skill

---

## Risk / Impact

Low. Additive — one new skill under an existing plugin; no changes to other skills, manifests, or CI. The verbs it documents are themselves experimental (gated behind `resourceCommands`), and the skill says so.

---

## Checklist

- [x] Linter passes (`scripts/review-skills.py . --strict`) — no findings for this skill
- [ ] Version bumped in `marketplace.json` if behavior materially changed — n/a (additive skill, no plugin behavior change)
- [ ] CHANGELOG updated under `[Unreleased]` — can add on request
- [x] No secrets, customer names, or internal URLs

---

**Source:** verbs implemented in https://github.com/rudderlabs/rudder-iac/pull/633 (`cli/internal/cmd/{get,describe,delete,setexternalid}`, scoped `apply -f`, `cli/internal/resourceops/`).
